### PR TITLE
Windows wheels

### DIFF
--- a/ci/docker/python-wheel-manylinux-201x.dockerfile
+++ b/ci/docker/python-wheel-manylinux-201x.dockerfile
@@ -22,7 +22,6 @@ FROM ${base}
 RUN yum install -y autoconf \
     boost-devel \
     cmake \
-    curl \
     flex \
     git \
     wget \

--- a/ci/docker/python-wheel-windows.dockerfile
+++ b/ci/docker/python-wheel-windows.dockerfile
@@ -44,6 +44,17 @@ RUN choco install -r -y --no-progress python --version=%PYTHON_VERSION%
 RUN pip install -U pip
 
 # Install arrow via vcpkg
+RUN git clone https://github.com/Microsoft/vcpkg.git
+RUN call .\vcpkg\bootstrap-vcpkg.bat
+RUN .\vcpkg\vcpkg integrate install
+RUN git clone https://github.com/apache/arrow.git
+RUN .\vcpkg\vcpkg install \
+  --triplet x64-windows \
+  --x-manifest-root arrow\cpp \
+  --feature-flags=versions \
+  --clean-after-build
+
+RUN python -m pip install numpy
 COPY ci\\scripts\\install_arrow.bat C:\\hyperarrow\\ci\\scripts\\
 RUN C:\\hyperarrow\\ci\\scripts\\install_arrow.bat
 

--- a/ci/docker/python-wheel-windows.dockerfile
+++ b/ci/docker/python-wheel-windows.dockerfile
@@ -15,22 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
-
-# Install Visual Studio Build Tools
-RUN curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe ^
-RUN start /w vs_buildtools.exe --quiet --wait --norestart --nocache modify \
-        --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" \
-        --add Microsoft.VisualStudio.Workload.AzureBuildTools \
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 \
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 \
-        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
-        --remove Microsoft.VisualStudio.Component.Windows81SDK
-RUN del /q vs_buildtools.exe
-
-
-# Install Chocolatey
-RUN powershell -command Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+# based on mcr.microsoft.com/windows/servercore:ltsc2019
+# contains choco and vs2017 preinstalled
+FROM abrarov/msvc-2017:2.11.0
 
 # Install CMake and Git
 ARG cmake=3.21.4

--- a/ci/docker/python-wheel-windows.dockerfile
+++ b/ci/docker/python-wheel-windows.dockerfile
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# based on mcr.microsoft.com/windows/servercore:ltsc2019
+# contains choco and vs2017 preinstalled
+FROM abrarov/msvc-2017:2.11.0
+
+# Install CMake and Git
+ARG cmake=3.21.4
+RUN choco install --no-progress -r -y cmake --version=%cmake% --installargs 'ADD_CMAKE_TO_PATH=System' && \
+    choco install --no-progress -r -y gzip wget git
+
+# Add unix tools to path
+RUN setx path "%path%;C:\Program Files\Git\usr\bin"
+
+# Remove previous installations of python from the base image
+# NOTE: a more recent base image (tried with 2.12.1) comes with python 3.9.7
+# and the msi installers are failing to remove pip and tcl/tk "products" making
+# the subsequent choco python installation step failing for installing python
+# version 3.9.* due to existing python version
+RUN wmic product where "name like 'python%%'" call uninstall /nointeractive && \
+    rm -rf Python*
+
+ARG python=3.8
+RUN (if "%python%"=="3.7" setx PYTHON_VERSION 3.7.12) & \
+    (if "%python%"=="3.8" setx PYTHON_VERSION 3.8.11) & \
+    (if "%python%"=="3.9" setx PYTHON_VERSION 3.9.9) & \
+    (if "%python%"=="3.10" setx PYTHON_VERSION 3.10.1)
+RUN choco install -r -y --no-progress python --version=%PYTHON_VERSION%
+RUN pip install -U pip
+
+# Install arrow via vcpkg
+RUN mkdir /tmp
+RUN pushd /tmp
+RUN git clone https://github.com/Microsoft/vcpkg.git
+RUN cd vcpkg
+RUN ./bootstrap-vcpkg.sh
+RUN ./vcpkg integrate install
+RUN ./vcpkg install arrow
+RUN popd
+
+# Get Hyper Libraries
+RUN mkdir /tmp/tableau
+RUN wget -q "https://downloads.tableau.com/tssoftware/tableauhyperapi-cxx-windows-x86_64-release-hyperapi_release_26.0.0.13821.r1fbe38ce.zip" -O tmp.zip
+RUN unzip -q tmp.zip -d /tmp/tableau
+RUN rm tmp.zip
+RUN pushd /tmp/tableau
+RUN mv tableauhyperapi-cxx-windows-x86_64-release-hyperapi_release_26.0.0.13821.r1fbe38ce tableauhyperapi
+RUN popd

--- a/ci/scripts/get_tableau_libs.bat
+++ b/ci/scripts/get_tableau_libs.bat
@@ -1,0 +1,7 @@
+mkdir C:\tmp\tableau
+curl -SL --output tmp.zip "https://downloads.tableau.com/tssoftware/tableauhyperapi-cxx-windows-x86_64-release-hyperapi_release_26.0.0.13821.r1fbe38ce.zip"
+unzip -q tmp.zip -d C:\\tmp\\tableau
+rm tmp.zip
+pushd C:\\tmp\\tableau
+mv tableauhyperapi-cxx-windows-x86_64-release-hyperapi_release_26.0.0.13821.r1fbe38ce tableauhyperapi
+popd

--- a/ci/scripts/install_arrow.bat
+++ b/ci/scripts/install_arrow.bat
@@ -1,0 +1,8 @@
+mkdir C:\tmp
+pushd C:\tmp
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg integrate install
+.\vcpkg install arrow
+popd

--- a/ci/scripts/install_arrow.bat
+++ b/ci/scripts/install_arrow.bat
@@ -1,8 +1,7 @@
 mkdir C:\tmp
 pushd C:\tmp
 git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-.\bootstrap-vcpkg.bat
-.\vcpkg integrate install
-.\vcpkg install arrow
+.\vcpkg\bootstrap-vcpkg.bat
+.\vcpkg\vcpkg install arrow:x64-windows
+.\vcpkg\vcpkg integrate install
 popd

--- a/ci/scripts/install_arrow.bat
+++ b/ci/scripts/install_arrow.bat
@@ -4,7 +4,7 @@ cd arrow\cpp
 mkdir build
 cd build
 cmake ^
-    - G "Visual Studio 15 2017" -A x64 ^
+    -G "Visual Studio 15 2017" -A x64 ^
     -DARROW_DEPENDENCY_SOURCE=VCPKG ^
     -DARROW_COMPUTE=ON ^
     -DARROW_PYTHON=ON ^

--- a/ci/scripts/install_arrow.bat
+++ b/ci/scripts/install_arrow.bat
@@ -1,10 +1,12 @@
-mkdir C:\tmp
-pushd C:\tmp
-git clone https://github.com/Microsoft/vcpkg.git
-echo "Bootstrapping vcpkg"
-call .\vcpkg\bootstrap-vcpkg.bat
-echo "Running Arrow Install"
-.\vcpkg\vcpkg install arrow:x64-windows
-echo "Integrating vcpkg with Visual Studio"
-.\vcpkg\vcpkg integrate install
-popd
+@rem The vcpkg install for Apache Arrow does not include
+@rem the Python libraries we need, so need to build ourselves
+cd arrow\cpp
+mkdir build
+cd build
+cmake ^
+    - G "Visual Studio 15 2017" -A x64 ^
+    -DARROW_DEPENDENCY_SOURCE=VCPKG ^
+    -DARROW_COMPUTE=ON ^
+    -DARROW_PYTHON=ON ^
+    .. || exit /B 1
+cmake --build . --target install --config Release || exit /B 1

--- a/ci/scripts/install_arrow.bat
+++ b/ci/scripts/install_arrow.bat
@@ -1,7 +1,10 @@
 mkdir C:\tmp
 pushd C:\tmp
 git clone https://github.com/Microsoft/vcpkg.git
-.\vcpkg\bootstrap-vcpkg.bat
+echo "Bootstrapping vcpkg"
+call .\vcpkg\bootstrap-vcpkg.bat
+echo "Running Arrow Install"
 .\vcpkg\vcpkg install arrow:x64-windows
+echo "Integrating vcpkg with Visual Studio"
 .\vcpkg\vcpkg integrate install
 popd

--- a/ci/scripts/python_wheel_manylinux_build.sh
+++ b/ci/scripts/python_wheel_manylinux_build.sh
@@ -24,8 +24,8 @@ rm -rf /tmp/hyperarrow-build
 rm -rf /hyperarrow/python/dist
 rm -rf /hyperarrow/python/build
 rm -rf /hyperarrow/python/repaired_wheels
-rm -rf /hyperarrow/python/pyarrow/*.so
-rm -rf /hyperarrow/python/pyarrow/*.so.*
+rm -rf /hyperarrow/python/hyperarrow/*.so
+rm -rf /hyperarrow/python/hyperarrow/*.so.*
 
 mkdir /tmp/hyperarrow-build
 pushd /tmp/hyperarrow-build

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -47,7 +47,18 @@ pushd C:\hyperarrow\python
 
 pip install delvewheel
 @rem TODO - don't hard code dist name
-delvewheel repair --wheel-dir repaired_wheels ^
+delvewheel repair --wheel-dir repaired_wheels^
     dist\hyperarrow-0.0.1.dev0-cp38-abi3-win_amd64.whl ^
     --add-path "C:\Program Files\arrow\bin;C:\hyperarrow-build\src\Release;C:\tmp\tableau\tableauhyperapi\bin;C:\vcpkg\packages\re2_x64-windows\bin;C:\vcpkg\packages\utf8proc_x64-windows\bin"
+
+@rem Might be a bug but delvewheel makes hyperarrow.lib
+@rem instead of hyperarrow\.lib
+cd repaired_wheels
+wheel unpack hyperarrow-0.0.1.dev0-cp38-abi3-win_amd64.whl
+cd hyperarrow-0.0.1.dev0
+cp hyperarrow.libs/* hyperarrow
+rm -rf hyperarrow.libs
+@rem also need to place Hyper executable herein
+cp -r %HYPER_PATH%\bin\hyper hyperarrow\
+wheel pack hyperarrow
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -20,28 +20,22 @@
 echo "Building windows wheel..."
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+rm -rf C:\hyperarrow-build
 
-echo "=== (%PYTHON_VERSION%) Clear output directories and leftovers ==="
-del /s /q C:\hyperarrow-build
-del /s /q C:\hyperarrow\python\dist
-del /s /q C:\hyperarrow\python\build
-del /s /q C:\hyperarrow\python\hyperarrow\*.so
-del /s /q C:\hyperarrow\python\hyperarrow\*.so.*
-
-
-echo "=== (%PYTHON_VERSION%) Building Arrow C++ libraries ==="
-set CMAKE_GENERATOR=Visual Studio 15 2017 Win64
+echo "=== (%PYTHON_VERSION%) Building HyperArrow libraries ==="
 set HYPER_PATH=C:\tmp\tableau\tableauhyperapi
 
 python -m pip install wheel
 mkdir C:\hyperarrow-build
 pushd C:\hyperarrow-build
+
 cmake ^
     -DCMAKE_PREFIX_PATH=%HYPER_PATH%\share\cmake ^
-    -DCMAKE_TOOLCHAIN_FILE="C:/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake" ^
-    -G "%CMAKE_GENERATOR%" ^
+    -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake ^
+    -DVCPKG_MANIFEST_DIR=C:\arrow\cpp ^
+    -G "Visual Studio 15 2017" -A x64 ^
     C:\hyperarrow || exit /B 1
-cmake --build . --target python || exit /B 1
+cmake --build . --config Release --target python || exit /B 1
 popd
 
 pushd C:\hyperarrow\python

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -21,6 +21,11 @@ echo "Building windows wheel..."
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 rm -rf C:\hyperarrow-build
+rm -rf C:\hyperarrow\python\dist
+rm -rf C:\hyperarrow\python\build
+rm -rf C:\hyperarrow\python\repaired_wheels
+rm -rf C:\hyperarrow\python\hyperarrow\*.dll
+rm -rf C:\hyperarrow\python\hyperarrow\*.dll.*
 
 echo "=== (%PYTHON_VERSION%) Building HyperArrow libraries ==="
 set HYPER_PATH=C:\tmp\tableau\tableauhyperapi
@@ -39,6 +44,10 @@ cmake --build . --config Release --target python || exit /B 1
 popd
 
 pushd C:\hyperarrow\python
-@REM bundle the msvc runtime
-cp "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x64\Microsoft.VC141.CRT\msvcp140.dll" hyperarrow
+
+pip install delvewheel
+@rem TODO - don't hard code dist name
+delvewheel repair --wheel-dir repaired_wheels ^
+    dist\hyperarrow-0.0.1.dev0-cp38-abi3-win_amd64.whl ^
+    --add-path "C:\Program Files\arrow\bin;C:\hyperarrow-build\src\Release;C:\tmp\tableau\tableauhyperapi\bin;C:\vcpkg\packages\re2_x64-windows\bin;C:\vcpkg\packages\utf8proc_x64-windows\bin"
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -31,12 +31,13 @@ del /s /q C:\hyperarrow\python\hyperarrow\*.so.*
 
 echo "=== (%PYTHON_VERSION%) Building Arrow C++ libraries ==="
 set CMAKE_GENERATOR=Visual Studio 15 2017 Win64
-set HYPER_PATH="C:\tmp\tableau\tableauhyperapi"
+set HYPER_PATH=C:\tmp\tableau\tableauhyperapi
 
+python -m pip install wheel
 mkdir C:\hyperarrow-build
 pushd C:\hyperarrow-build
 cmake ^
-    -DCMAKE_PREFIX_PATH=%HYPER_PATH% ^
+    -DCMAKE_PREFIX_PATH=%HYPER_PATH%\share\cmake ^
     -DCMAKE_TOOLCHAIN_FILE="C:/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake" ^
     -G "%CMAKE_GENERATOR%" ^
     C:\hyperarrow || exit /B 1
@@ -46,5 +47,4 @@ popd
 pushd C:\hyperarrow\python
 @REM bundle the msvc runtime
 cp "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x64\Microsoft.VC141.CRT\msvcp140.dll" hyperarrow
-python setup.py bdist_wheel || exit /B 1
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -1,0 +1,50 @@
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem   http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+
+@echo on
+
+echo "Building windows wheel..."
+
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+echo "=== (%PYTHON_VERSION%) Clear output directories and leftovers ==="
+del /s /q C:\hyperarrow-build
+del /s /q C:\hyperarrow\python\dist
+del /s /q C:\hyperarrow\python\build
+del /s /q C:\hyperarrow\python\hyperarrow\*.so
+del /s /q C:\hyperarrow\python\hyperarrow\*.so.*
+
+
+echo "=== (%PYTHON_VERSION%) Building Arrow C++ libraries ==="
+set CMAKE_GENERATOR=Visual Studio 15 2017 Win64
+set HYPER_PATH="C:\tmp\tableau\tableauhyperapi"
+
+mkdir C:\hyperarrow-build
+pushd C:\hyperarrow-build
+cmake ^
+    -DCMAKE_PREFIX_PATH=%HYPER_PATH% ^
+    -DCMAKE_TOOLCHAIN_FILE="C:/tmp/vcpkg/scripts/buildsystems/vcpkg.cmake" ^
+    -G "%CMAKE_GENERATOR%" ^
+    C:\hyperarrow || exit /B 1
+cmake --build . --target python || exit /B 1
+popd
+
+pushd C:\hyperarrow\python
+@REM bundle the msvc runtime
+cp "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x64\Microsoft.VC141.CRT\msvcp140.dll" hyperarrow
+python setup.py bdist_wheel || exit /B 1
+popd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,5 +87,8 @@ services:
       context: .
       dockerfile: ci/docker/python-wheel-windows.dockerfile
     volumes:
-      - .:/hyperarrow:delegated
+      - "C:/Users/PC/clones/hyperarrow"
+      - type: bind
+        source: .
+        target: "C:/hyperarrow"
     command: hyperarrow\\ci\\scripts\\python_wheel_windows_build.bat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,8 @@
 volumes:
   python-wheel-manylinux2014:
     name: python-wheel-manylinux2014
+  python-wheel-windows:
+    name: python-wheel-windows
 
 services:
 
@@ -75,3 +77,15 @@ services:
     volumes:
       - .:/hyperarrow:delegated
     command: /hyperarrow/ci/scripts/python_wheel_manylinux_build.sh
+
+  python-wheel-windows:
+    image: hyperarrow:python-38-wheel-windows
+    build:
+      args:
+        base: mcr.microsoft.com/windows/servercore:ltsc2019
+        python: "3.8"
+      context: .
+      dockerfile: ci/docker/python-wheel-windows.dockerfile
+    volumes:
+      - .:/hyperarrow:delegated
+    command: hyperarrow\\ci\\scripts\\python_wheel_windows_build.bat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,6 @@ services:
       context: .
       dockerfile: ci/docker/python-wheel-windows.dockerfile
     volumes:
-      - type: bind
-        source: .
-        target: c:\hyperarrow
+      - .:c:\hyperarrow
+    cpu_count: 8
     command: hyperarrow\\ci\\scripts\\python_wheel_windows_build.bat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,8 +87,7 @@ services:
       context: .
       dockerfile: ci/docker/python-wheel-windows.dockerfile
     volumes:
-      - "C:/Users/PC/clones/hyperarrow"
       - type: bind
         source: .
-        target: "C:/hyperarrow"
+        target: c:\hyperarrow
     command: hyperarrow\\ci\\scripts\\python_wheel_windows_build.bat

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 from glob import glob
 
@@ -9,23 +10,30 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-
+# TODO: on Linux we need to set LD_LIBRARY_PATH for auditwheel to copy
+# this in, so maybe can leverage that instead of repeating here
+# For cross platform, maybe we figure out how to install the tableauhyper lib
+tableau_dir = os.environ["HYPER_PATH"]    
+include_dirs = ["../include"]
+library_dirs = [str(pathlib.Path(tableau_dir) / "lib")]
 # MSVC compiler has different flags; assume that's what we are using on Windows
 if os.name == "nt":
     # Enable extra warnings except implicit cast, which throws a few
     # see https://bugzilla.mozilla.org/show_bug.cgi?id=857863 for justification
     extra_compile_args = ["/WX", "/wd4244"]
+
+    # The docker python wheel build assumes this location
+    # May not be used in other cases
+    include_dirs.append("C:/Program Files/arrow/include")
+    library_dirs.append("C:/Program Files/arrow/lib")
+    # This is not great to hard code this to match Docker :-(
+    library_dirs.append("C:/hyperarrow-build/src/Release")
 else:
     # Would love to add -Werror here but looks like the tableauhyperapi
     # ships with a few
     extra_compile_args = ["-Wextra", "-std=c++11"]
     if "--debug" in sys.argv:
         extra_compile_args.extend(["-g", "-UNDEBUG", "-O0"])
-
-# TODO: on Linux we need to set LD_LIBRARY_PATH for auditwheel to copy
-# this in, so maybe can leverage that instead of repeating here
-# For cross platform, maybe we figure out how to install the tableauhyper lib
-tableau_dir = os.environ["HYPER_PATH"]
 
 extra_link_args = []
 if sys.platform == "darwin":
@@ -34,7 +42,7 @@ if sys.platform == "darwin":
 
 hyperarrow_module = Extension(
     "hyperarrow.libhyperarrow",
-    include_dirs=["../include"],
+    include_dirs=include_dirs,
     # TODO: need to figure out a better way to distribute hyperarrow
     # include files as well as libraries; for now hard-coded to
     # expected build folder location
@@ -45,7 +53,7 @@ hyperarrow_module = Extension(
         "hyperarrow_reader",
         "tableauhyperapi",
     ],
-    library_dirs=[tableau_dir + "/lib"],
+    library_dirs=library_dirs,
     extra_link_args=extra_link_args,
     sources=list(glob("hyperarrow/hyperarrow.cpp")),
     extra_compile_args=extra_compile_args,


### PR DESCRIPTION
PyArrow isn't built against the Py_LIMITED_API so unfortunately will need to remove that in a subsequent update. But for now this builds 3.8 wheels